### PR TITLE
Config key to override default Page

### DIFF
--- a/config/filament-spatie-laravel-backup.php
+++ b/config/filament-spatie-laravel-backup.php
@@ -10,9 +10,13 @@ return [
     | This is the configuration for the general appearance of the page
     | in admin panel.
     |
+    | Override is an option to create a new Backup page for customize it,
+    | default is false to use Backup Component Page.
+    |
     */
 
     'page' => [
+        'override' => false,
         'navigation' => [
             'sort' => null,
         ],

--- a/resources/lang/pt_BR/backup.php
+++ b/resources/lang/pt_BR/backup.php
@@ -1,0 +1,69 @@
+<?php
+
+return [
+
+	'components' => [
+		'backup_destination_list' => [
+			'table' => [
+				'actions' => [
+					'download' => 'Download',
+					'delete'   => 'Excluir',
+				],
+
+				'fields' => [
+					'path' => 'Caminho',
+					'disk' => 'Disco',
+					'date' => 'Data',
+					'size' => 'Tamanho',
+				],
+
+				'filters' => [
+					'disk' => 'Disco'
+				],
+			]
+		],
+
+		'backup_destination_status_list' => [
+			'table' => [
+				'fields' => [
+					'name'         => 'Nome',
+					'disk'         => 'Disco',
+					'healthy'      => 'Saúde',
+					'amount'       => 'Quant.',
+					'newest' 	   => 'Recente',
+					'used_storage' => 'Espaço utilizado',
+				],
+			]
+		],
+	],
+
+	'pages' => [
+		'backups' => [
+			'actions' => [
+				'create_backup' => 'Criar Backup',
+			],
+
+			'heading' => 'Backups',
+
+			'messages' => [
+				'backup_success' => 'Criando um novo em segundo plano.'
+			],
+
+			'modal' => [
+				'buttons' => [
+					'only_db'      => 'Apenas DB',
+					'only_files'   => 'Apenas arquivos',
+					'db_and_files' => 'DB & Arquivos',
+				],
+
+				'label' => 'Por favor, escolha uma opção',
+			],
+
+			'navigation' => [
+				'group' => 'Configurações',
+				'label' => 'Backups',
+			],
+		],
+	],
+
+];

--- a/src/FilamentSpatieLaravelBackupServiceProvider.php
+++ b/src/FilamentSpatieLaravelBackupServiceProvider.php
@@ -34,6 +34,10 @@ class FilamentSpatieLaravelBackupServiceProvider extends PluginServiceProvider
 
     protected function getPages(): array
     {
+        if (config('filament-spatie-laravel-backup.page.override')) {
+            return [];
+        }
+
         return [
             Backups::class,
         ];


### PR DESCRIPTION
Create a config key to override a default Backup Page by customize with a new page.

I create this to use a trait to implement permission using bezhanSalleh/filament-shield.

this a sample of new page:
```
<?php

namespace App\Filament\Pages;

use BezhanSalleh\FilamentShield\Traits\HasPageShield;
use Filament\Pages\Page;
use ShuvroRoy\FilamentSpatieLaravelBackup\Pages\Backups;

class NewBackups extends Backups
{
    use HasPageShield;

//    protected static string $view = 'filament.pages.new-backups';
}
```
