### PR TITLE
fix: display status by overriding the function

### DIFF
--- a/resources/views/pages/backups.blade.php
+++ b/resources/views/pages/backups.blade.php
@@ -1,5 +1,5 @@
 <x-filament::page>
-    @if(!$this->getHideBackupStatusTable())
+    @if($this->shouldDisplayStatusListRecords())
         @livewire(ShuvroRoy\FilamentSpatieLaravelBackup\Components\BackupDestinationStatusListRecords::class)
     @endif
     <div class="!mt-8">

--- a/src/Pages/Backups.php
+++ b/src/Pages/Backups.php
@@ -56,13 +56,8 @@ class Backups extends Page
         $this->notify('success', __('filament-spatie-backup::backup.pages.backups.messages.backup_success'));
     }
 
-    public function hideBackupStatusTable(bool $condition = true): void
+    public function shouldDisplayStatusListRecords(): bool
     {
-        $this->hideBackupStatusTable = $condition;
-    }
-
-    public function getHideBackupStatusTable(): bool
-    {
-        return $this->hideBackupStatusTable;
+        return true;
     }
 }


### PR DESCRIPTION
I thought it was working as a filament component but overriding the function it's enough to display or not