### PR TITLE
Fix undefined SIGINT by using artisan to call spatie backup.

### DIFF
--- a/src/Enums/Option.php
+++ b/src/Enums/Option.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace ShuvroRoy\FilamentSpatieLaravelBackup\Enums;
+
+enum Option: string
+{
+    case ONLY_DB = 'only-db';
+    case ONLY_FILES = 'only-files';
+    case ALL = '';
+}

--- a/src/Jobs/CreateBackupJob.php
+++ b/src/Jobs/CreateBackupJob.php
@@ -6,7 +6,9 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
-use Spatie\Backup\Tasks\Backup\BackupJobFactory;
+use Illuminate\Support\Facades\Artisan;
+use ShuvroRoy\FilamentSpatieLaravelBackup\Enums\Option;
+use Spatie\Backup\Commands\BackupCommand;
 
 class CreateBackupJob implements ShouldQueue
 {
@@ -14,31 +16,20 @@ class CreateBackupJob implements ShouldQueue
     use InteractsWithQueue;
     use Queueable;
 
-    protected string $option;
-
-    public function __construct(string $option = '')
-    {
-        $this->option = $option;
-    }
+    public function __construct(
+        protected readonly Option $option = Option::ALL
+    ){}
 
     public function handle(): void
     {
-        $backupJob = BackupJobFactory::createFromArray(config('backup'));
-
-        if ($this->option === 'only-db') {
-            $backupJob->dontBackupFilesystem();
-        }
-
-        if ($this->option === 'only-files') {
-            $backupJob->dontBackupDatabases();
-        }
-
-        if (! empty($this->option)) {
-            $prefix = str_replace('_', '-', $this->option) . '-';
-
-            $backupJob->setFilename($prefix . date('Y-m-d-H-i-s') . '.zip');
-        }
-
-        $backupJob->run();
+        Artisan::call(BackupCommand::class, [
+            '--only-db' => $this->option === Option::ONLY_DB,
+            '--only-files' => $this->option === Option::ONLY_FILES,
+            '--filename' => match ($this->option) {
+                Option::ALL => null,
+                default => str_replace('_', '-', $this->option->value).
+                    '-'.date('Y-m-d-H-i-s').'.zip'
+            },
+        ]);
     }
 }

--- a/src/Pages/Backups.php
+++ b/src/Pages/Backups.php
@@ -6,6 +6,7 @@ use Filament\Actions\Action;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
 use Illuminate\Contracts\Support\Htmlable;
+use ShuvroRoy\FilamentSpatieLaravelBackup\Enums\Option;
 use ShuvroRoy\FilamentSpatieLaravelBackup\FilamentSpatieLaravelBackupPlugin;
 use ShuvroRoy\FilamentSpatieLaravelBackup\Jobs\CreateBackupJob;
 
@@ -50,7 +51,7 @@ class Backups extends Page
         /** @var FilamentSpatieLaravelBackupPlugin $plugin */
         $plugin = filament()->getPlugin('filament-spatie-backup');
 
-        dispatch(new CreateBackupJob($option))
+        CreateBackupJob::dispatch(Option::from($option))
             ->onQueue($plugin->getQueue())
             ->afterResponse();
 


### PR DESCRIPTION
Hi!, instead of using this:
```php
$backupJob->disableSignals();
```

see:
https://github.com/spatie/laravel-backup/blob/64f4b816c61f802e9f4c831a589c9d2e21573ddd/src/Commands/BackupCommand.php#L61

much better to use artisan so internal process of spatie did not touch

best regards 