### PR TITLE
Fix typo in interval methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ class AdminPanelProvider extends PanelProvider
             // ...
             ->plugin(
                 FilamentSpatieLaravelBackupPlugin::make()
-                    ->usingPolingInterval('10s') // default value is 4s
+                    ->usingPollingInterval('10s') // default value is 4s
             );
     }
 }

--- a/src/Components/BackupDestinationListRecords.php
+++ b/src/Components/BackupDestinationListRecords.php
@@ -102,6 +102,6 @@ class BackupDestinationListRecords extends Component implements HasForms, HasTab
         /** @var FilamentSpatieLaravelBackupPlugin $plugin */
         $plugin = filament()->getPlugin('filament-spatie-backup');
 
-        return $plugin->getPolingInterval();
+        return $plugin->getPollingInterval();
     }
 }

--- a/src/Components/BackupDestinationStatusListRecords.php
+++ b/src/Components/BackupDestinationStatusListRecords.php
@@ -61,6 +61,6 @@ class BackupDestinationStatusListRecords extends Component implements HasForms, 
         /** @var FilamentSpatieLaravelBackupPlugin $plugin */
         $plugin = filament()->getPlugin('filament-spatie-backup');
 
-        return $plugin->getPolingInterval();
+        return $plugin->getPollingInterval();
     }
 }

--- a/src/FilamentSpatieLaravelBackupPlugin.php
+++ b/src/FilamentSpatieLaravelBackupPlugin.php
@@ -62,14 +62,30 @@ class FilamentSpatieLaravelBackupPlugin implements Plugin
         return $this->queue;
     }
 
+    /**
+     * @deprecated 2.2.0 Deprecated for the typo in the name. May be removed in a future major release. Use {@see \ShuvroRoy\FilamentSpatieLaravelBackup\FilamentSpatieLaravelBackupPlugin::usingPollingInterval} instead.
+     */
     public function usingPolingInterval(string $interval): static
+    {
+        return $this->usingPollingInterval($interval);
+    }
+
+    public function usingPollingInterval(string $interval): static
     {
         $this->interval = $interval;
 
         return $this;
     }
 
+    /**
+     * @deprecated 2.2.0 Deprecated for the typo in the name. May be removed in a future major release. Use {@see \ShuvroRoy\FilamentSpatieLaravelBackup\FilamentSpatieLaravelBackupPlugin::getPollingInterval} instead.
+     */
     public function getPolingInterval(): string
+    {
+        return $this->getPollingInterval();
+    }
+
+    public function getPollingInterval(): string
     {
         return $this->interval;
     }


### PR DESCRIPTION
There were typos in two methods:
* `\ShuvroRoy\FilamentSpatieLaravelBackup\FilamentSpatieLaravelBackupPlugin::usingPolingInterval`
* `\ShuvroRoy\FilamentSpatieLaravelBackup\FilamentSpatieLaravelBackupPlugin::getPolingInterval`

This PR deprecates these two methods and introduces two new ones:
* `\ShuvroRoy\FilamentSpatieLaravelBackup\FilamentSpatieLaravelBackupPlugin::usingPollingInterval`
* `\ShuvroRoy\FilamentSpatieLaravelBackup\FilamentSpatieLaravelBackupPlugin::getPollingInterval`

The deprecated methods delegate their implementation to the correctly spelled ones