### PR TITLE
feat(BackupsPage): update getNavigationGroup return type

### DIFF
--- a/src/Pages/Backups.php
+++ b/src/Pages/Backups.php
@@ -21,7 +21,7 @@ class Backups extends Page
         return __('filament-spatie-backup::backup.pages.backups.heading');
     }
 
-    public static function getNavigationGroup(): ?string
+    public static function getNavigationGroup(): string | \UnitEnum | null
     {
         return __('filament-spatie-backup::backup.pages.backups.navigation.group');
     }


### PR DESCRIPTION
This allows the backups page to be added to an enum-based navigation group, one of the new features in Filament v4.

https://filamentphp.com/docs/4.x/navigation/overview#registering-navigation-groups-with-an-enum