### PR TITLE
chore(deps): add Laravel 13 compatibility (spatie/laravel-backup ^10.0)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.2",
         "filament/filament": "^4.0|^5.0",
-        "spatie/laravel-backup": "^8.0|^9.0",
+        "spatie/laravel-backup": "^8.0|^9.0|^10.0",
         "spatie/laravel-package-tools": "^1.9"
     },
     "require-dev": {


### PR DESCRIPTION
This PR updates the `spatie/laravel-backup` version constraint in `composer.json` to add support for `^10.0`, which is required for **Laravel 13** compatibility.

### Changes

- `composer.json`: updated `spatie/laravel-backup` from `^8.0|^9.0` to `^8.0|^9.0|^10.0`

### Testing

- Tested locally on a real Laravel 13 project with no errors or breaking changes.
- Existing functionality (backup, download, delete, etc.) works as expected.