### PR TITLE
fix: respect app timezone when formatting backup dates

### DIFF
--- a/src/FilamentSpatieLaravelBackup.php
+++ b/src/FilamentSpatieLaravelBackup.php
@@ -44,7 +44,7 @@ class FilamentSpatieLaravelBackup
                     return [
                         'disk' => $disk,
                         'path' => $backup->path(),
-                        'date' => $backup->date()->format('Y-m-d H:i:s'),
+                        'date' => $backup->date()->setTimezone(config('app.timezone'))->format('Y-m-d H:i:s'),
                         'size' => Format::humanReadableSize($backup->sizeInBytes()),
                     ];
                 })


### PR DESCRIPTION
## Summary

- When a backup filename doesn't match the `Y-m-d-H-i-s.zip` pattern (e.g. a custom-prefixed filename), Spatie's `Backup::date()` falls back to `Carbon::createFromTimestamp()`, which returns a UTC `Carbon` instance.
- Without an explicit timezone conversion, `format('Y-m-d H:i:s')` then prints the wall-clock in UTC, so the table column shows a time offset from the user's configured app timezone.
- This converts the date to `config('app.timezone')` before formatting so the displayed value matches what the user expects.

```diff
- 'date' => $backup->date()->format('Y-m-d H:i:s'),
+ 'date' => $backup->date()->setTimezone(config('app.timezone'))->format('Y-m-d H:i:s'),
```

## Test plan

- [ ] Configure a non-UTC `app.timezone` (e.g. `Europe/Zurich`).
- [ ] Create a backup whose filename does not match `Y-m-d-H-i-s.zip` (custom prefix).
- [ ] Open the Filament Backups page and confirm the `date` column reflects the app timezone, not UTC.
- [ ] Verify that backups with the default filename pattern still display correctly (no regression).