### PR TITLE
Fix route registration in multi-panel apps

### DIFF
--- a/src/Pages/Backups.php
+++ b/src/Pages/Backups.php
@@ -4,8 +4,11 @@ namespace ShuvroRoy\FilamentSpatieLaravelBackup\Pages;
 
 use Filament\Actions\Action;
 use Filament\Clusters\Cluster;
+use Filament\Facades\Filament;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
+use Filament\Pages\PageConfiguration;
+use Filament\Panel;
 use Illuminate\Contracts\Support\Htmlable;
 use ShuvroRoy\FilamentSpatieLaravelBackup\Enums\BackupType;
 use ShuvroRoy\FilamentSpatieLaravelBackup\FilamentSpatieLaravelBackupPlugin;
@@ -18,6 +21,19 @@ class Backups extends Page
     public function getHeading(): string | Htmlable
     {
         return FilamentSpatieLaravelBackupPlugin::get()->getHeading();
+    }
+
+    public static function registerRoutes(Panel $panel, ?PageConfiguration $configuration = null): void
+    {
+        $currentPanel = Filament::getCurrentPanel();
+
+        Filament::setCurrentPanel($panel);
+
+        try {
+            parent::registerRoutes($panel, $configuration);
+        } finally {
+            Filament::setCurrentPanel($currentPanel);
+        }
     }
 
     /** @return class-string<Cluster>|null */

--- a/tests/PluginTest.php
+++ b/tests/PluginTest.php
@@ -4,6 +4,8 @@ use Filament\Clusters\Cluster;
 use Filament\Contracts\Plugin as FilamentPlugin;
 use Filament\Facades\Filament;
 use Filament\Panel;
+use Filament\PanelRegistry;
+use Illuminate\Support\Facades\Route;
 use ShuvroRoy\FilamentSpatieLaravelBackup\FilamentSpatieLaravelBackupPlugin;
 use ShuvroRoy\FilamentSpatieLaravelBackup\Pages\Backups;
 
@@ -84,6 +86,26 @@ it('resolves cluster configuration from the current panel', function () {
 
     Filament::setCurrentPanel($plainPanel);
     expect(Backups::getCluster())->toBeNull();
+});
+
+it('registers routes when the plugin is not on the default panel', function () {
+    $defaultPanel = Panel::make()
+        ->default()
+        ->id('student');
+    $backupPanel = Panel::make()
+        ->id('admin')
+        ->plugin(FilamentSpatieLaravelBackupPlugin::make()->cluster(PluginTestCluster::class));
+
+    app(PanelRegistry::class)->register($defaultPanel);
+    app(PanelRegistry::class)->register($backupPanel);
+    Filament::setCurrentPanel(null);
+
+    Backups::registerRoutes($backupPanel);
+
+    expect(Filament::getCurrentPanel())->toBeNull()
+        ->and(collect(Route::getRoutes()->getRoutesByName())->keys()->contains(
+            fn (string $name): bool => str_starts_with($name, 'plugin-test.pages.'),
+        ))->toBeTrue();
 });
 
 it('makes no timeout visible to the queue worker', function () {


### PR DESCRIPTION
## Summary

- register backup page routes using the panel currently being processed
- restore the previous Filament panel after route registration
- add regression coverage for a default panel without the plugin and a non-default clustered backup panel

## Validation

- 44 tests passed (188 assertions)
- Laravel Pint passed
- PHPStan passed

Fixes #126